### PR TITLE
Add base_path config option to specify alternative installation path

### DIFF
--- a/lib/distillery_packager/debian/config.ex
+++ b/lib/distillery_packager/debian/config.ex
@@ -7,7 +7,7 @@ defmodule DistilleryPackager.Debian.Config do
 
   defstruct name: nil, version: nil, arch: nil, description: nil, vendor: nil,
             maintainers: nil, homepage: nil, external_dependencies: nil,
-            maintainer_scripts: [], config_files: [],
+            maintainer_scripts: [], config_files: [], base_path: "/opt",
             additional_files: [], owner: [user: "root", group: "root"]
 
   use Vex.Struct
@@ -24,6 +24,7 @@ defmodule DistilleryPackager.Debian.Config do
   validates :vendor, presence: true
   validates :maintainers, presence: true
   validates :homepage, presence: true
+  validates :base_path, presence: true
   validates [:owner, :user], presence: true
   validates [:owner, :group], presence: true
 
@@ -91,6 +92,9 @@ defmodule DistilleryPackager.Debian.Config do
   end
   defp handle_config(:vendor, value) when byte_size(value) > 0 do
     {:vendor, value}
+  end
+  defp handle_config(:base_path, value) do
+    {:base_path, Path.absname(value, "/")}
   end
   defp handle_config(:owner, value) when is_list(value) do
     handle_config(:owner, Enum.into(value, %{}))

--- a/lib/distillery_packager/debian/data.ex
+++ b/lib/distillery_packager/debian/data.ex
@@ -39,7 +39,7 @@ defmodule DistilleryPackager.Debian.Data do
   # We don't use/need the .tar.gz file built by Distillery Packager, so
   # remove it from the data dir to reduce filesize.
   defp remove_targz_file(data_dir, config) do
-    [data_dir, "opt", config.name, "#{config.name}-#{config.version}.tar.gz"]
+    [data_dir, config.base_path, config.name, "#{config.name}-#{config.version}.tar.gz"]
       |> Path.join
       |> File.rm
   end
@@ -48,13 +48,13 @@ defmodule DistilleryPackager.Debian.Data do
     debug("Building debian data directory")
     data_dir = Path.join([dir, "data"])
     :ok = File.mkdir_p(data_dir)
-    :ok = File.mkdir_p(Path.join([data_dir, "opt", config.name]))
+    :ok = File.mkdir_p(Path.join([data_dir, config.base_path, config.name]))
 
     data_dir
   end
 
   defp copy_release(data_dir, config) do
-    dest = Path.join([data_dir, "opt", config.name])
+    dest = Path.join([data_dir, config.base_path, config.name])
     src = src_path(config)
 
     debug("Copying #{src} into #{dest} directory")

--- a/lib/distillery_packager/debian/data.ex
+++ b/lib/distillery_packager/debian/data.ex
@@ -39,7 +39,8 @@ defmodule DistilleryPackager.Debian.Data do
   # We don't use/need the .tar.gz file built by Distillery Packager, so
   # remove it from the data dir to reduce filesize.
   defp remove_targz_file(data_dir, config) do
-    [data_dir, config.base_path, config.name, "#{config.name}-#{config.version}.tar.gz"]
+    [data_dir, config.base_path, config.name,
+    "#{config.name}-#{config.version}.tar.gz"]
       |> Path.join
       |> File.rm
   end

--- a/lib/distillery_packager/debian/generators/systemd.ex
+++ b/lib/distillery_packager/debian/generators/systemd.ex
@@ -15,6 +15,7 @@ defmodule DistilleryPackager.Debian.Generators.Systemd do
         |> EEx.eval_file([
             description: config.description,
             name: config.name,
+            base_path: config.base_path,
             uid: config.owner[:user],
             gid: config.owner[:group]
         ])

--- a/lib/distillery_packager/debian/generators/sysvinit.ex
+++ b/lib/distillery_packager/debian/generators/sysvinit.ex
@@ -15,6 +15,7 @@ defmodule DistilleryPackager.Debian.Generators.Sysvinit do
         |> EEx.eval_file([
             description: config.description,
             name: config.name,
+            base_path: config.base_path,
             uid: config.owner[:user]
         ])
 

--- a/lib/distillery_packager/debian/generators/upstart.ex
+++ b/lib/distillery_packager/debian/generators/upstart.ex
@@ -15,6 +15,7 @@ defmodule DistilleryPackager.Debian.Generators.Upstart do
         |> EEx.eval_file([
             description: config.description,
             name: config.name,
+            base_path: config.base_path,
             uid: config.owner[:user],
             gid: config.owner[:group]
         ])

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule DistilleryPackager.Mixfile do
 
   def project do
     [app: :distillery_packager,
-     version: "1.0.1",
+     version: "1.0.2",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/templates/debian/init_scripts/systemd.service.eex
+++ b/templates/debian/init_scripts/systemd.service.eex
@@ -14,10 +14,10 @@ Environment=HOME=/root
 Environment=HOME=/home/<%= uid %>
 <% end %>
 
-WorkingDirectory=/opt/<%= name %>
+WorkingDirectory=<%= base_path %>/<%= name %>
 
-ExecStart=/opt/<%= name %>/bin/<%= name %> start
-ExecStop=/opt/<%= name %>/bin/<%= name %> stop
+ExecStart=<%= base_path %>/<%= name %>/bin/<%= name %> start
+ExecStop=<%= base_path %>/<%= name %>/bin/<%= name %> stop
 
 Restart=on-failure
 RemainAfterExit=yes

--- a/templates/debian/init_scripts/sysvinit.eex
+++ b/templates/debian/init_scripts/sysvinit.eex
@@ -17,7 +17,7 @@
 
 DAEMON_NAME=<%= name %>
 DAEMON_USER=<%= uid %>
-DAEMON_PATH=/opt/<%= name %>/bin/<%= name %>
+DAEMON_PATH=<%= base_path %>/<%= name %>/bin/<%= name %>
 
 DAEMON_DESC=$(get_lsb_header_val $0 "Short-Description")
 DAEMON_NICE=0

--- a/templates/debian/init_scripts/upstart.conf.eex
+++ b/templates/debian/init_scripts/upstart.conf.eex
@@ -19,6 +19,6 @@ env HOME=/home/<%= uid %>
 <% end %>
 export HOME
 
-pre-start exec /bin/sh /opt/<%= name %>/bin/<%= name %> start
+pre-start exec /bin/sh <%= base_path %>/<%= name %>/bin/<%= name %> start
 
-post-stop exec /bin/sh /opt/<%= name %>/bin/<%= name %> stop
+post-stop exec /bin/sh <%= base_path %>/<%= name %>/bin/<%= name %> stop

--- a/test/distillery_packager/data_test.exs
+++ b/test/distillery_packager/data_test.exs
@@ -34,7 +34,7 @@ defmodule DistilleryPackagerTest.DataTest do
 
     dest_test_file = Path.join([
       meta.config.test_dir,
-      "opt",
+      meta.config.metadata.base_path,
       meta.config.metadata.name,
       "test_file"
     ])

--- a/test/distillery_packager/tasks_test.exs
+++ b/test/distillery_packager/tasks_test.exs
@@ -4,7 +4,7 @@ defmodule DistilleryPackagerTest.TasksTest do
   alias DistilleryPackager.Utils.Config, as: ConfigUtil
 
   setup_all do
-    dest = [ConfigUtil.root, "rel"] |> Path.join
+    dest = ConfigUtil.rel_dest_path()
 
     Mix.Tasks.Release.Deb.PrepareBasePath.run(:test)
     Mix.Tasks.Release.Deb.GenerateTemplates.run(:test)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -22,7 +22,8 @@ defmodule TestHelper do
       config_files:          ["dummy_file"],
       owner:                 [user: "root", group: "root"],
       additional_files:      [],
-      test_mode:             true
+      test_mode:             true,
+      base_path:             "/opt"
     } |> DistilleryPackager.Utils.Config.sanitize_config
   end
 end


### PR DESCRIPTION
This adds a `base_path` config option, and defaults to `/opt` path if not specified to preserve previous behaviour.