### PR TITLE
Don't include Depends in control file when there are no dependencies

### DIFF
--- a/lib/distillery_packager/debian/generators/control.ex
+++ b/lib/distillery_packager/debian/generators/control.ex
@@ -22,7 +22,7 @@ defmodule DistilleryPackager.Debian.Generators.Control do
           installed_size: config.installed_size,
           external_dependencies: config.external_dependencies,
           homepage: config.homepage
-        ])
+        ], [trim: true])
 
     :ok = File.write(Path.join([control_dir, "control"]), out)
   end

--- a/templates/debian/control.eex
+++ b/templates/debian/control.eex
@@ -4,7 +4,9 @@ Vendor: <%= vendor %>
 Architecture: <%= arch %>
 Maintainer: <%= maintainers %>
 Installed-Size: <%= installed_size %>
+<%= if external_dependencies != nil do %>
 Depends: <%= external_dependencies %>
+<% end %>
 Priority: optional
 Section: utils
 Homepage: <%= homepage %>


### PR DESCRIPTION
If the Depends line is blank in the deb control file, apt complains on update. This ensures a blank depends line isn't present.