### PR TITLE
Debian package naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ A list of configuration options you can add to `deb_package/0`:
    - If set, requires both `user` and `group` keys to be set.
    - This is used when building the archive to set the correct user and group
    - Defaults to root for user & group.
+ - `package_name`
+   - String
+   - Specify a custom .deb package name, overriding the default which is based on the OTP release name
 
 ## Distillery configuration
 

--- a/lib/distillery_packager.ex
+++ b/lib/distillery_packager.ex
@@ -16,7 +16,7 @@ defmodule DistilleryPackager do
     :ok = Package.build(deb_root, config)
 
     info("A debian package has been created " <>
-         "in ./rel/#{config.name}-#{config.version}_#{config.arch}.deb")
+         "in ./rel/#{config.sanitized_name}-#{config.version}_#{config.arch}.deb")
   end
 
   def remove_deb_dir do

--- a/lib/distillery_packager.ex
+++ b/lib/distillery_packager.ex
@@ -16,7 +16,7 @@ defmodule DistilleryPackager do
     :ok = Package.build(deb_root, config)
 
     info("A debian package has been created " <>
-         "in ./rel/#{config.sanitized_name}-#{config.version}_#{config.arch}.deb")
+         "in ./rel/#{Package.filename(config)}")
   end
 
   def remove_deb_dir do

--- a/lib/distillery_packager/debian/config.ex
+++ b/lib/distillery_packager/debian/config.ex
@@ -8,7 +8,8 @@ defmodule DistilleryPackager.Debian.Config do
   defstruct name: nil, version: nil, arch: nil, description: nil, vendor: nil,
             maintainers: nil, homepage: nil, external_dependencies: nil,
             maintainer_scripts: [], config_files: [], base_path: "/opt",
-            additional_files: [], owner: [user: "root", group: "root"]
+            additional_files: [], owner: [user: "root", group: "root"],
+            package_name: nil
 
   use Vex.Struct
 
@@ -102,6 +103,9 @@ defmodule DistilleryPackager.Debian.Config do
   defp handle_config(:owner, %{user: user, group: group})
       when user != nil and group != nil do
     {:owner, [user: user, group: group]}
+  end
+  defp handle_config(:package_name, value) do
+    {:package_name, value}
   end
   defp handle_config(_, _), do: nil
 

--- a/lib/distillery_packager/debian/package.ex
+++ b/lib/distillery_packager/debian/package.ex
@@ -12,7 +12,7 @@ defmodule DistilleryPackager.Debian.Package do
 
     out = Path.join([
       ConfigUtil.rel_dest_path,
-      "#{config.sanitized_name}-#{config.version}_#{config.arch}.deb"
+      filename(config)
     ])
 
     File.rm out
@@ -28,5 +28,9 @@ defmodule DistilleryPackager.Debian.Package do
     {_response, 0} = System.cmd("ar", args)
 
     :ok
+  end
+
+  def filename(config) do
+    "#{config.sanitized_name}_#{config.version}_#{config.arch}.deb"
   end
 end

--- a/lib/distillery_packager/utils/config.ex
+++ b/lib/distillery_packager/utils/config.ex
@@ -24,7 +24,7 @@ defmodule DistilleryPackager.Utils.Config do
     sanitized_name =
       config.name
         |> String.downcase
-        |> String.replace(~r([^a-z\-\_\.]), "")
+        |> String.replace(~r([^a-z0-9+\-_.]), "")
         |> String.replace("_", "-")
 
     Map.put(config, :sanitized_name, sanitized_name)

--- a/lib/distillery_packager/utils/config.ex
+++ b/lib/distillery_packager/utils/config.ex
@@ -26,8 +26,25 @@ defmodule DistilleryPackager.Utils.Config do
         |> String.downcase
         |> String.replace(~r([^a-z0-9+\-_.]), "")
         |> String.replace("_", "-")
+        |> validate_package_name
 
     Map.put(config, :sanitized_name, sanitized_name)
+  end
+
+  def validate_package_name(name) when is_binary(name) do
+    if Regex.match?(~r/^[a-z0-9][a-z0-9.+-]+$/, name) do
+      name
+    else
+      """
+      Error: Debian package names must consist only of lower case
+      letters (a-z), digits (0-9), plus (+) and minus (-) signs,
+      and periods (.). They must be at least two characters long
+      and must start with an alphanumeric character.
+      """
+      |> String.trim
+      |> String.replace("\n", " ")
+      |> throw
+    end
   end
 
   @doc """

--- a/lib/distillery_packager/utils/config.ex
+++ b/lib/distillery_packager/utils/config.ex
@@ -25,6 +25,7 @@ defmodule DistilleryPackager.Utils.Config do
       config.name
         |> String.downcase
         |> String.replace(~r([^a-z\-\_\.]), "")
+        |> String.replace("_", "-")
 
     Map.put(config, :sanitized_name, sanitized_name)
   end

--- a/lib/distillery_packager/utils/config.ex
+++ b/lib/distillery_packager/utils/config.ex
@@ -18,19 +18,33 @@ defmodule DistilleryPackager.Utils.Config do
   end
 
   @doc """
-  Sanitize certain elements so that they are filesystem safe.
+  Sanitize certain elements so that they are filesystem safe, and fit within
+  the Debian policy / conventions.
   """
   def sanitize_config(config = %{}) do
-    sanitized_name =
-      config.name
-        |> String.downcase
-        |> String.replace(~r([^a-z0-9+\-_.]), "")
-        |> String.replace("_", "-")
-        |> validate_package_name
-
-    Map.put(config, :sanitized_name, sanitized_name)
+    Map.put(config, :sanitized_name, package_name(config))
   end
 
+  @doc """
+  Return a package name to use; either the provided `package_name` from
+  configuration, or a sanitized version of `name` as a default.
+  """
+  def package_name(%{package_name: name}) when is_binary(name) do
+    validate_package_name(name)
+  end
+
+  def package_name(config = %{}) do
+    config.name
+      |> String.downcase
+      |> String.replace(~r([^a-z0-9+\-_.]), "")
+      |> String.replace("_", "-")
+      |> validate_package_name
+  end
+
+  @doc """
+  Validate the provided package name and return it, or throw an error if it
+  doesn't match against expectations.
+  """
   def validate_package_name(name) when is_binary(name) do
     if Regex.match?(~r/^[a-z0-9][a-z0-9.+-]+$/, name) do
       name

--- a/test/distillery_packager/config_test.exs
+++ b/test/distillery_packager/config_test.exs
@@ -1,10 +1,34 @@
 defmodule DistilleryPackagerTest.ConfigTest do
   use ExUnit.Case, async: false
 
-  test "Configuration is sanitized correctly" do
-    out = %{ name: "$!JIM-B+O.B,'" }
-      |> DistilleryPackager.Utils.Config.sanitize_config()
+  import DistilleryPackager.Utils.Config, only: [sanitize_config: 1,
+                                                 validate_package_name: 1]
 
-    assert Map.fetch!(out, :sanitized_name) == "jim-bo.b"
+  test "Configuration is sanitized correctly" do
+    out = sanitize_config(%{ name: "0$!JIM-B+O.B,'" })
+    assert Map.fetch!(out, :sanitized_name) == "0jim-b+o.b"
+  end
+
+  test "Sanitized configuration is validated" do
+    catch_throw sanitize_config(%{ name: "-$!JIM-B+O.B,'" })
+  end
+
+  test "Package name allows a-z, 0-9, '+', '-' and '.'" do
+    allowed_chars = "fo0-bar+ba.azd"
+    assert validate_package_name(allowed_chars) == allowed_chars
+  end
+
+  test "Package name must have at least two characters" do
+    assert validate_package_name("aa") == "aa"
+    catch_throw validate_package_name("a")
+  end
+
+  test "Package name must begin with an alphanumeric character" do
+    assert validate_package_name("0a") == "0a"
+    catch_throw validate_package_name("+foo")
+  end
+
+  test "Package name must not contain upper-case letters" do
+    catch_throw validate_package_name("Foo")
   end
 end

--- a/test/distillery_packager/config_test.exs
+++ b/test/distillery_packager/config_test.exs
@@ -1,16 +1,27 @@
 defmodule DistilleryPackagerTest.ConfigTest do
   use ExUnit.Case, async: false
 
+  alias DistilleryPackager.Debian.Config, as: DebConfig
+
   import DistilleryPackager.Utils.Config, only: [sanitize_config: 1,
                                                  validate_package_name: 1]
 
   test "Configuration is sanitized correctly" do
-    out = sanitize_config(%{ name: "0$!JIM-B+O.B,'" })
+    out = sanitize_config(%DebConfig{ name: "0$!JIM-B+O.B,'" })
     assert Map.fetch!(out, :sanitized_name) == "0jim-b+o.b"
   end
 
   test "Sanitized configuration is validated" do
-    catch_throw sanitize_config(%{ name: "-$!JIM-B+O.B,'" })
+    catch_throw sanitize_config(%DebConfig{ name: "-$!JIM-B+O.B,'" })
+  end
+
+  test "Given a 'package_name' setting, use it as 'sanitized_name'" do
+    out = sanitize_config(%DebConfig{ name: "app_name", package_name: "some-package" })
+    assert Map.fetch!(out, :sanitized_name) == "some-package"
+  end
+
+  test "Given a 'package_name' setting, it is NOT sanitized" do
+    catch_throw sanitize_config(%DebConfig{ package_name: "0$!JIM-B+O.B,'" })
   end
 
   test "Package name allows a-z, 0-9, '+', '-' and '.'" do


### PR DESCRIPTION
I'd like to propose some changes:

  - Clean up package name, allowing 0-9 as well as `+`, and converting underscores (`_`) to dashes (`-`)

    According to the [Debian Policy](https://www.debian.org/doc/debian-policy/#s-f-source):

    > Package names (both source and binary, see Package) must consist only of lower
    > case letters (a-z), digits (0-9), plus (+) and minus (-) signs, and periods (.).
    >They must be at least two characters long and must start with an alphanumeric
    > character.

  - Use underscore instead of dash when separating _package name_ and _package version_ in the resulting `.deb` file

    From the [Debian FAQ](https://www.debian.org/doc/manuals/debian-faq/ch-pkg_basics#s-pkgname):
    
    > The Debian binary package file names conform to the following convention:
    > `<foo>_<VersionNumber>-<DebianRevisionNumber>_<DebianArchitecture>.deb`

  - Enable overriding the generated package name by using the `package_name` setting