### PR TITLE
Debian packaging compliance (file perms + init script)

### DIFF
--- a/lib/distillery_packager/debian/control.ex
+++ b/lib/distillery_packager/debian/control.ex
@@ -18,6 +18,7 @@ defmodule DistilleryPackager.Debian.Control do
     Control.build(config, control_dir)
     add_custom_hooks(config, control_dir)
     add_conffiles_file(config, control_dir)
+    System.cmd("chmod", ["-R", "og-w", control_dir])
     Compression.compress(
       control_dir,
       Path.join([control_dir, "..", "control.tar.gz"])

--- a/lib/distillery_packager/debian/control.ex
+++ b/lib/distillery_packager/debian/control.ex
@@ -21,7 +21,8 @@ defmodule DistilleryPackager.Debian.Control do
     System.cmd("chmod", ["-R", "og-w", control_dir])
     Compression.compress(
       control_dir,
-      Path.join([control_dir, "..", "control.tar.gz"])
+      Path.join([control_dir, "..", "control.tar.gz"]),
+      owner: %{user: "root", group: "root"}
     )
     DistilleryPackager.Utils.File.remove_tmp(control_dir)
 

--- a/lib/distillery_packager/debian/data.ex
+++ b/lib/distillery_packager/debian/data.ex
@@ -26,6 +26,7 @@ defmodule DistilleryPackager.Debian.Data do
       DistilleryPackager.Utils.File.get_dir_size(data_dir)
     )
 
+    System.cmd("chmod", ["-R", "og-w", data_dir])
     Compression.compress(
       data_dir,
       Path.join([data_dir, "..", "data.tar.gz"]),

--- a/templates/debian/init_scripts/sysvinit.eex
+++ b/templates/debian/init_scripts/sysvinit.eex
@@ -92,9 +92,10 @@ do_usage() {
 }
 
 case "$1" in
-start)   do_start;   exit $? ;;
-stop)    do_stop;    exit $? ;;
-restart) do_restart; exit $? ;;
-status)  do_status;  exit $? ;;
-*)       do_usage;   exit  1 ;;
+start)        do_start;   exit $? ;;
+stop)         do_stop;    exit $? ;;
+restart)      do_restart; exit $? ;;
+force-reload) do_restart; exit $? ;;
+status)       do_status;  exit $? ;;
+*)            do_usage;   exit  1 ;;
 esac


### PR DESCRIPTION
Some changes driven by a 'lintian' check of the resulting .deb file:

  - Remove write permissions for group/others on all files in the release (some scripts were even 0777, a bit risky..)
  - Ensure that control files are owned by `root`
  - Tweak sysvinit template to generate the missing `force-reload` action required by LSB